### PR TITLE
Vercel 배포 문재로 인한 설정 업데이트 Create main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: git push into another repo to deploy to vercel
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTH_TOKEN }}
+        with:
+          source-directory: 'output'
+          destination-github-username: goldmayo
+          destination-repository-name: asac-marketplace
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
### PR 타입

- [ ]  기능 **추가 - Add**
- [ ]  기능 **삭제 - Delete**
- [ ]  기능 **수정 - Update**
- [ X ]  의존성, 환경 변수, 빌드 업데이트

### 태스크 티켓

- Projects 이슈 링크

### 리뷰어에게 부탁

- vercel에서 organization의 프로젝트는 pro 계정을 사용해야 하기 때문에 개인 레포로 fork하여 배포하였고,
- 개인 레포와 팀 레포의 싱크를 맞추기 위해 github action작업 추가했습니다 
